### PR TITLE
Get the content-type from the wirter.

### DIFF
--- a/Exporter/Exporter.php
+++ b/Exporter/Exporter.php
@@ -43,19 +43,15 @@ class Exporter
         switch ($format) {
             case 'xls':
                 $writer = new XlsWriter('php://output');
-                $contentType = 'application/vnd.ms-excel';
                 break;
             case 'xml':
                 $writer = new XmlWriter('php://output');
-                $contentType = 'text/xml';
                 break;
             case 'json':
                 $writer = new JsonWriter('php://output');
-                $contentType = 'application/json';
                 break;
             case 'csv':
                 $writer = new CsvWriter('php://output', ',', '"', '', true, true);
-                $contentType = 'text/csv';
                 break;
             default:
                 throw new \RuntimeException('Invalid format');
@@ -67,7 +63,7 @@ class Exporter
         };
 
         return new StreamedResponse($callback, 200, array(
-            'Content-Type' => $contentType,
+            'Content-Type' => $writer->getDefaultMimeType(),
             'Content-Disposition' => sprintf('attachment; filename="%s"', $filename),
         ));
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because…
This change is backwards compatible. It does not add any new feature or change any existing behavior.
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Changed
- When exporting, get the content-type from the writer.
```
## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->
## Subject

<!-- Describe your Pull Request content here -->

The exporter is duplicating work by defining the mime types that go with different writers. The writers already defined their own mime types which can be used instead. This change uses the mime type defined on the writer instead.
